### PR TITLE
Updated Cuda Extensions to work with PyTorch 1.10+

### DIFF
--- a/extensions/emd/cuda/emd_kernel.cu
+++ b/extensions/emd/cuda/emd_kernel.cu
@@ -175,9 +175,9 @@ at::Tensor ApproxMatchForward(
   const auto n = xyz1.size(1);
   const auto m = xyz2.size(1);
 
-  CHECK_EQ(xyz2.size(0), b);
-  CHECK_EQ(xyz1.size(2), 3);
-  CHECK_EQ(xyz2.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(0), b);
+  TORCH_CHECK_EQ(xyz1.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(2), 3);
   CHECK_INPUT(xyz1);
   CHECK_INPUT(xyz2);
 
@@ -262,9 +262,9 @@ at::Tensor MatchCostForward(
   const auto n = xyz1.size(1);
   const auto m = xyz2.size(1);
 
-  CHECK_EQ(xyz2.size(0), b);
-  CHECK_EQ(xyz1.size(2), 3);
-  CHECK_EQ(xyz2.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(0), b);
+  TORCH_CHECK_EQ(xyz1.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(2), 3);
   CHECK_INPUT(xyz1);
   CHECK_INPUT(xyz2);
 
@@ -379,9 +379,9 @@ std::vector<at::Tensor> MatchCostBackward(
   const auto n = xyz1.size(1);
   const auto m = xyz2.size(1);
 
-  CHECK_EQ(xyz2.size(0), b);
-  CHECK_EQ(xyz1.size(2), 3);
-  CHECK_EQ(xyz2.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(0), b);
+  TORCH_CHECK_EQ(xyz1.size(2), 3);
+  TORCH_CHECK_EQ(xyz2.size(2), 3);
   CHECK_INPUT(xyz1);
   CHECK_INPUT(xyz2);
 

--- a/extensions/emd/cuda/emd_kernel.cu
+++ b/extensions/emd/cuda/emd_kernel.cu
@@ -11,7 +11,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>  // at::cuda::getApplyGrid
-#include <THC/THC.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
@@ -187,7 +187,7 @@ at::Tensor ApproxMatchForward(
   AT_DISPATCH_FLOATING_TYPES(xyz1.scalar_type(), "ApproxMatchForward", ([&] {
         approxmatch<scalar_t><<<32,512>>>(b, n, m, xyz1.data<scalar_t>(), xyz2.data<scalar_t>(), match.data<scalar_t>(), temp.data<scalar_t>());
   }));
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
 
   return match;
 }
@@ -273,7 +273,7 @@ at::Tensor MatchCostForward(
   AT_DISPATCH_FLOATING_TYPES(xyz1.scalar_type(), "MatchCostForward", ([&] {
         matchcost<scalar_t><<<32,512>>>(b, n, m, xyz1.data<scalar_t>(), xyz2.data<scalar_t>(), match.data<scalar_t>(), cost.data<scalar_t>());
   }));
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
 
   return cost;
 }
@@ -392,7 +392,7 @@ std::vector<at::Tensor> MatchCostBackward(
         matchcostgrad1<scalar_t><<<32,512>>>(b, n, m, grad_cost.data<scalar_t>(), xyz1.data<scalar_t>(), xyz2.data<scalar_t>(), match.data<scalar_t>(), grad1.data<scalar_t>());
         matchcostgrad2<scalar_t><<<dim3(32,32),256>>>(b, n, m, grad_cost.data<scalar_t>(), xyz1.data<scalar_t>(), xyz2.data<scalar_t>(), match.data<scalar_t>(), grad2.data<scalar_t>());
   }));
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
 
   return std::vector<at::Tensor>({grad1, grad2});
 }


### PR DESCRIPTION
Porting Guide: https://github.com/pytorch/pytorch/wiki/TH-to-ATen-porting-guide

The extensions now build successfully, tested on PyTorch 1.13.1