### PR TITLE
fix TORCH_CHECK_EQ macro undefined

### DIFF
--- a/extensions/emd/cuda/emd_kernel.cu
+++ b/extensions/emd/cuda/emd_kernel.cu
@@ -17,6 +17,9 @@
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
+#ifndef TORCH_CHECK_EQ
+#define TORCH_CHECK_EQ(val1, val2) CHECK_EQ(val1, val2)
+
 
 /********************************
 * Forward kernel for approxmatch


### PR DESCRIPTION
This PR fixes the error when building the emd_kernel extension with some older versions of Pytorch. The problem is caused by the previous PR #58, which change CHECK_EQ to the new TORCH_CHECK_EQ macro. However, TORCH_CHECK_EQ is only introduced in the newer version of Pytorch. See [Pytorch PR 82032](https://github.com/pytorch/pytorch/pull/82032)